### PR TITLE
Fix user info collection for paylike request

### DIFF
--- a/Paylike_Payment/app/design/frontend/base/default/template/paylike/form/paylike.phtml
+++ b/Paylike_Payment/app/design/frontend/base/default/template/paylike/form/paylike.phtml
@@ -173,6 +173,24 @@ if ( Mage::getStoreConfig( 'payment/paylike/status' ) ) {
                 if (publicKey) {
                     var paylike = Paylike(publicKey);
                     document.getElementById("paylike-transaction-id").removeAttribute("disabled");
+
+                    if (!paylikeVAR.name || !paylikeVAR.name.trim()) {
+                      var fname = document.querySelector("input[name=\"billing[firstname]\"]").value;
+                      var mname = document.querySelector("input[name=\"billing[middlename]\"]").value;
+                      var lname = document.querySelector("input[name=\"billing[lastname]\"]").value;
+                      paylikeVAR.name = [fname, mname, lname].filter(function(n) {
+                        return !!n;
+                      }).join(" ");
+                    }
+
+                    if (!paylikeVAR.email || !paylikeVAR.email.trim()) {
+                        paylikeVAR.email = document.querySelector("input[name=\"billing[email]\"]").value;
+                    }
+
+                    if (!paylikeVAR.telephone || !paylikeVAR.telephone.trim()) {
+                        paylikeVAR.telephone = document.querySelector("input[name=\"billing[telephone]\"]").value;
+                    }
+
                     var args = {
                         title: popupTitle,
                         currency: currency,


### PR DESCRIPTION
The issue here was that we were counting on the the checkout plugin
to refresh the payment section, when something changes, which was not
always the case; now, when that doesn't happen, we collect the info
directly from the inputs, when the user clicks "proceed to checkout"